### PR TITLE
bugfix action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
       run: |
         COMMITS=$(jq '.pull_request.commits // .commits | length' ${GITHUB_EVENT_PATH})
         echo "Commits found: $COMMITS"
-        MODIFIED=$(git diff-index HEAD~$COMMITS ${{ inputs.path }} | wc -l | awk '{print $1}')
+        MODIFIED=$(git diff-index HEAD~$COMMITS -- ${{ inputs.path }} | wc -l | awk '{print $1}')
         echo "Modified files: $MODIFIED"
-        echo "$(git diff-index --stat HEAD~$COMMITS ${{ inputs.path }})"
+        echo "$(git diff-index --stat HEAD~$COMMITS -- ${{ inputs.path }})"
         echo "modified=$MODIFIED" >> $GITHUB_OUTPUT


### PR DESCRIPTION
fix for action which was failing because module path was not being separated from revisions with `--` 
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/205f2ec8-1cda-4a3b-b615-691e6966a609" />

proof of the new branch working as intended:
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/2c77a141-ae81-433e-aef1-630921edf1f3" />